### PR TITLE
Fix: Handle oneOf schema validation in _generate_tool_inputs

### DIFF
--- a/src/mcpadapt/smolagents_adapter.py
+++ b/src/mcpadapt/smolagents_adapter.py
@@ -29,8 +29,26 @@ def _generate_tool_inputs(
     """
     inputs: dict[str, dict[str, str]] = {}
     for k, v in resolved_json_schema.items():
+        # Get type from direct type field, anyOf, or oneOf, handling None cases
+        type_value = v.get("type")
+        if type_value is None:
+            # Try anyOf
+            anyOf = v.get("anyOf")
+            if anyOf and len(anyOf) > 0:
+                type_value = anyOf[0].get("type")
+            
+            # If still None, try oneOf
+            if type_value is None:
+                oneOf = v.get("oneOf")
+                if oneOf and len(oneOf) > 0:
+                    type_value = oneOf[0].get("type")
+        
+        # Default to "string" if we still couldn't find a type
+        if type_value is None:
+            type_value = "string"
+            
         inputs[k] = {
-            "type": v.get("type") or v.get("anyOf")[0].get("type"),
+            "type": type_value,
             "description": v.get(
                 "description", ""
             ),  # TODO: use google-docstring-parser to parse description of args and pass it here...


### PR DESCRIPTION
## Description
This PR fixes an issue in the `_generate_tool_inputs` function where it fails to handle JSON schemas that use the `oneOf` validation keyword instead of `anyOf` or a direct `type` field.

## Problem
The current implementation tries to access `v.get("anyOf")[0]` when `v.get("anyOf")` returns `None`, causing a TypeError: 'NoneType' object is not subscriptable.

## Solution
The fix:
1. Restructures the type detection logic to handle multiple schema validation keywords
2. Adds support for the `oneOf` JSON Schema keyword
3. Adds proper null checks before accessing array indices
4. Provides a fallback to "string" type when no type could be determined

The updated code now:
- First tries to get the type directly from the "type" field
- If that's None, it tries to get it from "anyOf"
- If that's still None, it tries to get it from "oneOf"
- Finally, if no type could be determined, it defaults to "string"

This makes the adapter more robust when handling various JSON Schema constructs.